### PR TITLE
Update askAll to use mqc_eval_format and available APIs

### DIFF
--- a/Code/config.py
+++ b/Code/config.py
@@ -2,7 +2,7 @@
 import os
 
 # File paths
-QUESTION_FILE = "mcq_eval_formal.json"
+QUESTION_FILE = "mqc_eval_format.json"
 MODEL_FILE = "models.json"
 INTERACTION_LOG = "logs/interaction_log.json"
 ANSWERS_FILE = "results/answers.json"


### PR DESCRIPTION
## Summary
- use `mqc_eval_format.json` for question data
- add endpoints for API calls to OpenAI, Claude and Gemini
- skip vendors with missing API keys
- adapt question parsing to `question_id`/`prompt`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f0a325a648323819441553347fc6e